### PR TITLE
add #include <cassert> for the assert() macro

### DIFF
--- a/include/field_reflection.hpp
+++ b/include/field_reflection.hpp
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <climits>  // CHAR_BIT
 #include <limits>
 #include <source_location>
@@ -582,7 +583,7 @@ namespace field_reflection
             static wrapper<T> fake;  // NOLINT
         };
 
-        template <typename T, size_t N>  // NOLINT
+        template <typename T, std::size_t N>  // NOLINT
         consteval auto get_ptr() noexcept
         {
 #if defined(__clang__)


### PR DESCRIPTION
Added <cassert> include after got CE "error: use of undeclared identifier 'assert'" during the compilation of project that uses this library. Compiler is clang++ 19.0.0, OS is Ubuntu 24.04
Also added "std::" for the "size_t" at the template argument type of the function field_reflection::detailwrapper::get_ptr()
